### PR TITLE
development support

### DIFF
--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -1,10 +1,9 @@
 branch-defaults:
-  deploy:
-    environment: aequitas-pro
-    group_suffix: null
+  master:
 global:
   application_name: aequitas
   branch: null
+  environment: aequitas-pro
   default_ec2_keyname: aequitas
   default_platform: Python 3.6
   default_region: us-west-2

--- a/install
+++ b/install
@@ -81,7 +81,7 @@ require $PROJECT \
 # python libs
 
 install_lib() {
-  pip install -r requirement/dev.txt
+  pip install -Ur requirement/dev.txt && pip install -e .
 }
 
 # no great way to check that python libs installed;

--- a/manage.py
+++ b/manage.py
@@ -9,6 +9,12 @@ class Aequitas(LocalRoot):
 class Web(Local):
     """manage the aequitas webapp"""
 
+    class Dev(Local):
+        """run the web development server"""
+
+        def prepare(self):
+            return self.local['python']['-m', 'aequitas_webapp.basic_upload']
+
     class Env(Local):
         """manage the webapp environment"""
 


### PR DESCRIPTION
`./install` now installs the `aequitas` package but _in development mode_, so changes to the codebase are immediately reflected, even when imported through Python.

`manage web dev` now launches the web development server.