### PR TITLE
fixed file encoding

### DIFF
--- a/.ebextensions/options.config
+++ b/.ebextensions/options.config
@@ -1,4 +1,6 @@
 option_settings:
+  aws:elasticbeanstalk:application:environment:
+    LC_ALL: en_US.UTF-8
   aws:elasticbeanstalk:container:python:
     WSGIPath: src/aequitas_webapp/basic_upload.py
   aws:elasticbeanstalk:container:python:staticfiles:

--- a/manage.py
+++ b/manage.py
@@ -35,11 +35,27 @@ class Web(Local):
 
         ENV = 'aequitas-pro'
 
-        @ebmethod('-n', '--name', default=ENV,
-                  help=f"environment console to open (default: {ENV})")
+        def __init__(self, parser):
+            parser.add_argument(
+                '-n', '--name',
+                default=self.ENV,
+                help=f"environment name (default: {self.ENV})",
+            )
+
+        @ebmethod
         def console(self, args):
             """open the environment web console"""
-            return self.eb['console', args.name]
+            return (self.local.FG, self.eb['console', args.name])
+
+        @ebmethod
+        def logs(self, args):
+            """read environment logs"""
+            return (self.local.FG, self.eb['logs', args.name])
+
+        @ebmethod
+        def ssh(self, args):
+            """ssh into the EC2 instance"""
+            return (self.local.FG, self.eb['ssh', args.name])
 
         class Create(BeanstalkCommand):
             """create an environment"""
@@ -48,11 +64,6 @@ class Web(Local):
                 parser.add_argument(
                     '-v', '--version',
                     help='previous version label to deploy to new environment',
-                )
-                parser.add_argument(
-                    '-n', '--name',
-                    default=Web.Env.ENV,
-                    help=f"name the environment (default: {Web.Env.ENV})",
                 )
 
             def prepare(self, args):
@@ -73,11 +84,6 @@ class Web(Local):
             """deploy to an environment"""
 
             def __init__(self, parser):
-                parser.add_argument(
-                    '-n', '--name',
-                    default=Web.Env.ENV,
-                    help=f"environment to which to deploy (default: {Web.Env.ENV})",
-                )
                 parser.add_argument(
                     'version',
                     help='version label to apply',

--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,11 @@ with REQUIREMENTS_PATH.open() as requirements_file:
     REQUIREMENTS = list(stream_requirements(requirements_file))
 
 
-# (Read files with explicit encoding for targets like Elastic Beanstalk)
-
 setup(
     name='aequitas',
     version='0.4.0',
     # description="",
-    long_description=README_PATH.read_text(encoding='utf8'),
+    long_description=README_PATH.read_text(),
     author="Center for Data Science and Public Policy",
     author_email='datascifellows@gmail.com',
     url='https://github.com/dssg/aequitas-public',
@@ -42,7 +40,7 @@ setup(
     package_dir={'': 'src'},
     include_package_data=True,
     install_requires=REQUIREMENTS,
-    license=LICENSE_PATH.read_text(encoding='utf8'),
+    license=LICENSE_PATH.read_text(),
     zip_safe=False,
     keywords='bias aequitas',
     classifiers=[


### PR DESCRIPTION
...and added some useful web env management commands.

This was effing terrible to work out. But, I suppose, now we know a bit more about how dumb CentOS/RedHat can be. (And this is part of why it's preferable to ship Docker containers.)

Everything about the locale/encoding setup _looked_ perfectly fine; but, it seems, when running in a non-console environment, it mattered quite a lot that `LC_ALL` was unset.

Setting this environment variable to UTF-8 fixed the setup issue I'd fixed previously with a one-off hack; and, I've confirmed that it fixes the bias report for http://aequitas.dssg.io/report/sample1.

(With this merged, however, we should tag `0.5.0` and redeploy.)