### PR TITLE
Add dockerfile and enable docker running in serve.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.4.10
+FROM python:3.6.6
 COPY . /aequitas
 WORKDIR /aequitas
 RUN python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.5-alpine
+RUN apk update && apk upgrade && \
+apk add --no-cache bash git openssh
+RUN apk --update add --no-cache \ 
+    lapack-dev \ 
+    gcc \
+    freetype-dev
+COPY . /aequitas
+WORKDIR /aequitas
+RUN pip3 install --no-cache-dir --no-build-isolation git+https://github.com/dssg/aequitas.git
+ENTRYPOINT ["python"]
+CMD ["serve.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-FROM python:3.5-alpine
-RUN apk update && apk upgrade && \
-apk add --no-cache bash git openssh
-RUN apk --update add --no-cache \ 
-    lapack-dev \ 
-    gcc \
-    freetype-dev
+FROM continuumio/miniconda3:4.4.10
 COPY . /aequitas
 WORKDIR /aequitas
-RUN pip3 install --no-cache-dir --no-build-isolation git+https://github.com/dssg/aequitas.git
+RUN python setup.py install
 ENTRYPOINT ["python"]
 CMD ["serve.py"]

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,14 @@ You may then import the ``aequitas`` module from Python::
 
     aequitas-report
 
+Docker
+======
+Build and run within a Docker container::
+
+    docker build -t aequitas .
+
+    docker run -p 5000:5000 -e "HOST=0.0.0.0" aequitas
+
 Development
 ===========
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: '3.1'
-services:
-    app:
-        build: .
-        ports:
-            - "5000:5000"
-        environment:
-            - HOST=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+    app:
+        build: .
+        ports:
+            - "5000:5000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-version: '2'
+version: '3.1'
 services:
     app:
         build: .
         ports:
             - "5000:5000"
+        environment:
+            - HOST=0.0.0.0

--- a/serve.py
+++ b/serve.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import importlib
-
+import sys
 # Make WSGI app available to server as "application"
 from aequitas_webapp import app as application
 
@@ -12,4 +12,4 @@ importlib.import_module('aequitas_webapp.views')
 
 if __name__ == '__main__':
     # Run development server
-    application.run()
+    application.run(host='0.0.0.0')

--- a/serve.py
+++ b/serve.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import importlib
-import sys
+import os
 # Make WSGI app available to server as "application"
 from aequitas_webapp import app as application
 
@@ -9,7 +9,7 @@ from aequitas_webapp import app as application
 # (but don't import it into this namespace)
 importlib.import_module('aequitas_webapp.views')
 
-
 if __name__ == '__main__':
+    host = os.environ.get('HOST', '127.0.0.1')
     # Run development server
-    application.run(host='0.0.0.0')
+    application.run(host=host)


### PR DESCRIPTION
Hi, Is this of any interest or value? I have added a dockerfile, docker-compose.yml and updated serve.py so you can run aequitas in a docker container for local testing.

You can run with `docker-compose up`

and then access aequitas at localhost:5000

I needed to slightly alter serve.py so it could run the flask app with host '0.0.0.0' when running in docker.

Happy to make any tweaks / changes if needs be.



