### PR TITLE
Adds list cast to inferred attribute columns

### DIFF
--- a/src/aequitas/group.py
+++ b/src/aequitas/group.py
@@ -314,7 +314,7 @@ class Group(object):
         if not attr_cols:
             non_attr_cols = ["id", "model_id", "entity_id", score_col, label_col]
             # index of the columns that are protected attributes.
-            attr_cols = df.columns[~df.columns.isin(non_attr_cols)]
+            attr_cols = df.columns[~df.columns.isin(non_attr_cols)].tolist()
 
         necessary_cols = attr_cols + [score_col, label_col]
         for col in ["id", "model_id", "entity_id"]:


### PR DESCRIPTION
Fixes #120 

Adds a cast to the inferred attribute columns, which are of type `pandas.core.indexes.base.Index`. These are added in the line bellow, with a list comprised of `[score_col, label_col]`. The former class does not have a native implementation of sum with lists, but it can be casted to list (which can be added).