### PR TITLE
Add  warning message to plots on disparities of 0

### DIFF
--- a/src/aequitas/plot/bubble_disparity_chart.py
+++ b/src/aequitas/plot/bubble_disparity_chart.py
@@ -324,13 +324,35 @@ def __draw_threshold_bands(
 
 
 def __draw_threshold_text(
-    fairness_threshold, ref_group, chart_height, accessibility_mode=False
+    fairness_threshold, ref_group, chart_height, accessibility_mode=False, warnings=()
 ):
     """Draw text that helps to read the threshold elements of the chart."""
     font_color = (
         Annotation.font_color if accessibility_mode else Annotation.font_color_threshold
     )
-
+    warn_text = alt.Chart(DUMMY_DF).mark_text(
+        baseline="top",
+        align="left",
+        font=FONT,
+        fill=font_color,
+        fontSize=Annotation.font_size,
+        fontWeight=Annotation.font_weight,
+    )
+    n_warnings = 0
+    text_explanation = []
+    for group, metric in warnings:
+        y_size = chart_height * (1 - 2 / 3 * Disparity_Chart.padding_y) + Annotation.font_size * Annotation.line_spacing * (n_warnings + 1)
+        explanation_text_warning = warn_text.encode(
+            x=alt.value(0),
+            y=alt.value(y_size),
+            text=alt.value(
+                f"Groups {group} have {metric} of 0 (zero). This "
+                "does not allow for the calculation of relative disparities. "
+                "The groups will be absent in respective visualizations.",
+            )
+        )
+        n_warnings +=1
+        text_explanation.append(explanation_text_warning)
     threshold_text = (
         alt.Chart(DUMMY_DF)
         .mark_text(
@@ -351,7 +373,9 @@ def __draw_threshold_text(
         )
     )
 
-    return threshold_text
+    text_explanation.append(threshold_text)
+
+    return alt.layer(*(chart for chart in text_explanation))
 
 
 def __get_threshold_elements(
@@ -361,6 +385,7 @@ def __get_threshold_elements(
     chart_height,
     chart_width,
     accessibility_mode=False,
+    warnings=(),
 ):
     """Gets threshold elements (rules, bands and text) for the chart."""
 
@@ -391,7 +416,7 @@ def __get_threshold_elements(
 
     # HELPER TEXT
     threshold_text = __draw_threshold_text(
-        fairness_threshold, ref_group, chart_height, accessibility_mode
+        fairness_threshold, ref_group, chart_height, accessibility_mode, warnings
     )
 
     return threshold_rules + threshold_bands + threshold_text
@@ -512,8 +537,15 @@ def get_disparity_bubble_chart_components(
 ):
     """Creates the components necessary to plot the disparity chart."""
 
+    # Check for warnings in plot
+    metric_warnings = []
     # COMPUTE SCALED DISPARITIES
     for metric in metrics:
+        zero_metric_groups = plot_table[plot_table[f"{metric}_disparity"] == 0]
+        zero_values = zero_metric_groups["attribute_value"].values
+        if zero_values.any():
+            metric_warnings.append([zero_values, metric])
+
         plot_table[f"{metric}_disparity_scaled"] = plot_table.apply(
             lambda row: transform_ratio(row[f"{metric}_disparity"]), axis=1
         )
@@ -555,6 +587,7 @@ def get_disparity_bubble_chart_components(
             chart_height,
             chart_width,
             accessibility_mode,
+            metric_warnings
         )
 
         # ASSEMBLE CHART WITH THRESHOLD

--- a/src/aequitas/plot/commons/helpers.py
+++ b/src/aequitas/plot/commons/helpers.py
@@ -1,4 +1,6 @@
 import altair as alt
+import numpy as np
+
 from millify import millify, prettify
 
 
@@ -21,6 +23,8 @@ def transform_ratio(value):
     Read: 'how many times larger or smaller than reference disparity'."""
     if value >= 1:
         return value - 1
+    elif value == 0:
+        return np.nan
     else:
         return 1 - 1 / value
 


### PR DESCRIPTION
Fixes #124.

Adds message of warning for metrics of 0 to calculate relative disparities.
Allows plots to run with metrics of 0.