### PR TITLE
issue 122 disparity error fix

### DIFF
--- a/src/aequitas/bias.py
+++ b/src/aequitas/bias.py
@@ -272,10 +272,6 @@ class Bias(object):
                                                   specific_measures=selected_significance,
                                                   label_score_ref=None)
 
-            ref_groups_dict = assemble_ref_groups(df, ref_group_flag='_ref_group_value',
-                                                  specific_measures=selected_significance,
-                                                  label_score_ref=None)
-
             attr_cols = df['attribute_name'].unique()
 
             for attribute in attr_cols:

--- a/src/aequitas/plotting.py
+++ b/src/aequitas/plotting.py
@@ -44,8 +44,9 @@ def assemble_ref_groups(disparities_table, ref_group_flag='_ref_group_value',
         if len(specific_measures) < 1:
             raise ValueError("At least one metric must be passed for which to "
                              "find refrence group.")
-
-        specific_measures = specific_measures.union({label_score_ref})
+        if label_score_ref:
+            specific_measures = specific_measures.union({label_score_ref})
+        
         ref_group_cols = {measure + ref_group_flag for measure in specific_measures if
              measure + ref_group_flag in ref_group_cols}
 


### PR DESCRIPTION
This is a fix for https://github.com/dssg/aequitas/issues/122

- Removed the same line of code being called twice in `bias.py`:`get_disparity_major_group`
- Added a check to skip adding `label_score_ref` to `specific_measures` when `label_score_ref` is `None` in `plotting.py`:`assemble_ref_groups`. This was the root cause of the error.