### PR TITLE
Issue 165 - Fix for Rounding Issue in adjusted_frac

### DIFF
--- a/src/aequitas/flow/datasets/generic.py
+++ b/src/aequitas/flow/datasets/generic.py
@@ -180,6 +180,7 @@ class GenericDataset(Dataset):
                 original_size = remainder_df.shape[0]
                 for key, value in self.splits.items():
                     adjusted_frac = (original_size / remainder_df.shape[0]) * value
+                    adjusted_frac = min(adjusted_frac, 1.0)
                     sample = remainder_df.sample(
                         frac=adjusted_frac, random_state=self.seed
                     )


### PR DESCRIPTION
I've added a modification in the create_splits method. Specifically, I've included a line to cap the value of adjusted_frac at 1.
As Replace="False" by default for sample method, this code fix might be sufficient.
