### PR TITLE
Remove loc with non existing indexes

### DIFF
--- a/src/aequitas/flow/methods/preprocessing/label_flipping.py
+++ b/src/aequitas/flow/methods/preprocessing/label_flipping.py
@@ -273,7 +273,7 @@ class LabelFlipping(PreProcessing):
                 if self.ordering_method == "residuals"
                 else y_flipped.loc[scores <= 0].index
             )
-            to_flip = pd.Series(index=flip_index).fillna(False).loc[y_flipped.index]
+            to_flip = pd.Series(index=flip_index).fillna(False)
             for group, flips in group_flips.items():
                 if flips > 0:
                     labels = y == 0


### PR DESCRIPTION
Fixes #204 

Somehow, we were using `loc` with indexes that we filtered previously. We need to add more tests to this file in the future, since it has some complex logic...